### PR TITLE
Add /options/<name> route

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -76,13 +76,26 @@ class ACFtoWPAPI{
 	}
 
 	/**
+	 * Option/<name> endpoint
+	 * @param $name
+	 * @return mixed
+	 */
+	function getACFOption($name) {
+		return get_field($name, 'option');
+	}
+
+	/**
 	 * Custom routes
 	 */
 	function registerRoutes( $routes ) {
-		$routes['/option'] = array(
+		// all the options
+		$routes['/options'] = array(
 			array(array(&$this, 'getACFOptions'), WP_JSON_Server::READABLE)
 		);
-
+		// a specific option
+		$routes['/options/(?P<name>[\w-]+)'] = array(
+			array( array( $this, 'getACFOption' ), WP_JSON_Server::READABLE ),
+		);
 		return $routes;
 	}
 


### PR DESCRIPTION
Hi, 

actually the ACF plugin has a bug when you creates pages and add options into it. It returns only the first page when you call the get_fields() method.
So, in order to wait properly for a fix in ACF I update your plugin accordingly : 
- pluralize the "option" route to follow th RESTfull standard
- add options/<name> to get a specific option
