### PR TITLE
Add ACF fields to a page

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -100,6 +100,7 @@ class ACFtoWPAPI {
 	private function _versionTwoSetup() {
 		// Actions
 		add_action( 'rest_api_init', array( $this, 'addACFDataPostV2' ) ); // Posts
+		add_action( 'rest_api_init', array( $this, 'addACFDataPageV2' ) ); // Pages
 		add_action( 'rest_api_init', array( $this, 'addACFDataTermV2' ) ); // Taxonomy Terms
 		add_action( 'rest_api_init', array( $this, 'addACFDataUserV2' ) ); // Users
 		add_action( 'rest_api_init', array( $this, 'addACFDataCommentV2' ) ); // Comments
@@ -224,6 +225,24 @@ class ACFtoWPAPI {
 	            'schema'          => null,
 	        )
 	    );
+	}
+
+	/**
+	 * Registers the `acf` field against pages
+	 *
+	 * @return void
+	 *
+	 * @since 1.3.0
+	 */
+	function addACFDataPageV2() {
+		register_api_field( 'page',
+			'acf',
+			array(
+				'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
+				'update_callback' => null,
+				'schema'          => null,
+			)
+		);
 	}
 	
 	/**


### PR DESCRIPTION
This adds acf fields to pages when pulled over the API.

It re-uses `ACFtoWPAPI::addACFDataPostV2cb()` to grab the data as I can't a reason to separate these into different methods, seeing as they're basically the same in core.

Happy to separate them if you'd prefer though?
