### PR TITLE
Compatibility fix for V2.0Beta9

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -37,7 +37,7 @@ class ACFtoWPAPI {
         $this->plugin->url = WP_PLUGIN_URL . '/' . str_replace(basename( __FILE__), "", plugin_basename(__FILE__));
 		$this->plugin->version = '1.3.2';
 
-		$this->apiVersion = get_option( 'rest_api_plugin_version', get_option( 'json_api_plugin_version', null ) );
+		$this->apiVersion = (REST_API_VERSION) ?: get_option( 'rest_api_plugin_version', get_option( 'json_api_plugin_version', null ) );
 
 		// Version One
 		if($this->_isAPIVersionOne()) {


### PR DESCRIPTION
it seems REST_API_VERSION is now the way to get the version number.
