### PR TITLE
Update custom post type criteria

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -238,7 +238,7 @@ class ACFtoWPAPI {
 
 		// Public custom post types
 		$types = get_post_types(array(
-			'public' => true,
+			'publicly_queryable' => true,
 			'_builtin' => false
 		));
 		foreach($types as $key => $type) {


### PR DESCRIPTION
I feel like limiting the post types that the acf field gets added to is currently incorrect, let says you have some blocks on a homepage that you want to be able to query using `get_posts` but you don't want each individually viewable, you would set that `post_type` to `public: false, publicly_queryable: true`

The small change I PR'd fixes this scenario, allowing you to see ACF fields for those types of post types.
