### PR TITLE
Add support for custom taxonomies when using V2 of the API

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -289,6 +289,25 @@ class ACFtoWPAPI {
 	            'schema'          => null,
 	        )
 	    );
+
+	    // Public taxonomies
+		$taxonomies = get_taxonomies(array(
+			'public'   => true,
+			'_builtin' => false
+
+		));
+
+		foreach($taxonomies as $key => $taxonomy) {
+
+			register_api_field( $taxonomy,
+				'acf',
+				array(
+					'get_callback'    => array( $this, 'addACFDataTermV2cb' ),
+					'update_callback' => null,
+					'schema'          => null,
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hi,
I do not know when but suddenly acf custom fields for custom taxonomies stopped working. After adding this code everything back to normal. 
