### PR TITLE
Replaced register_api_field() with register_rest_field() to work with…

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -218,7 +218,7 @@ class ACFtoWPAPI {
 	 */
 	function addACFDataPostV2() {
 		// Posts
-		register_api_field( 'post',
+		register_rest_field( 'post',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -228,7 +228,7 @@ class ACFtoWPAPI {
 	    );
 
 		// Pages
-		register_api_field( 'page',
+		register_rest_field( 'page',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -243,7 +243,7 @@ class ACFtoWPAPI {
 			'_builtin' => false
 		));
 		foreach($types as $key => $type) {
-			register_api_field( $type,
+			register_rest_field( $type,
 		        'acf',
 		        array(
 		            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -281,7 +281,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataTermV2() {
-		register_api_field( 'term',
+		register_rest_field( 'term',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataTermV2cb' ),
@@ -318,7 +318,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataUserV2() {
-		register_api_field( 'user',
+		register_rest_field( 'user',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataUserV2cb' ),
@@ -355,7 +355,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataCommentV2() {
-		register_api_field( 'comment',
+		register_rest_field( 'comment',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataCommentV2cb' ),

--- a/docs/files/acf-to-wp-api.php.txt
+++ b/docs/files/acf-to-wp-api.php.txt
@@ -217,7 +217,7 @@ class ACFtoWPAPI {
 	 */
 	function addACFDataPostV2() {
 		// Posts
-		register_api_field( 'post',
+		register_rest_field( 'post',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -227,7 +227,7 @@ class ACFtoWPAPI {
 	    );
 
 		// Pages
-		register_api_field( 'page',
+		register_rest_field( 'page',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -242,7 +242,7 @@ class ACFtoWPAPI {
 			'_builtin' => false
 		));
 		foreach($types as $key => $type) {
-			register_api_field( $type,
+			register_rest_field( $type,
 		        'acf',
 		        array(
 		            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -280,7 +280,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataTermV2() {
-		register_api_field( 'term',
+		register_rest_field( 'term',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataTermV2cb' ),
@@ -317,7 +317,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataUserV2() {
-		register_api_field( 'user',
+		register_rest_field( 'user',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataUserV2cb' ),
@@ -354,7 +354,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataCommentV2() {
-		register_api_field( 'comment',
+		register_rest_field( 'comment',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataCommentV2cb' ),


### PR DESCRIPTION
WP 4.7 doesn't support register_api_field() instead switched to register_rest_field().

> BREAKING CHANGE: Rename register_api_field() to register_rest_field().

> Introduces a register_api_field() function for backwards compat, which calls _doing_it_wrong(). However, register_api_field() won't ever be committed to WordPress core, so you should update your function calls.