### PR TITLE
V2 compliance: register_api_field is now register_rest_field

### DIFF
--- a/acf-to-wp-api.php
+++ b/acf-to-wp-api.php
@@ -47,7 +47,7 @@ class ACFtoWPAPI {
 
 		// Version Two
 		if($this->_isAPIVersionTwo()) {
-			$this->_versionTwoSetup();	
+			$this->_versionTwoSetup();
 		}
 	}
 	/**
@@ -56,7 +56,7 @@ class ACFtoWPAPI {
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
 	 *
 	 * @param mixed 	$data 	The data to be dumped to the screen
-	 * 
+	 *
 	 * @return void
 	 *
 	 * @since 1.3.0
@@ -144,7 +144,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	private function _isAPIVersionOne() {
-		if($this->_getAPIBaseVersion() === 1) { 
+		if($this->_getAPIBaseVersion() === 1) {
 			return true;
 		}
 
@@ -159,7 +159,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	private function _isAPIVersionTwo() {
-		if($this->_getAPIBaseVersion() === 2) { 
+		if($this->_getAPIBaseVersion() === 2) {
 			return true;
 		}
 
@@ -218,7 +218,7 @@ class ACFtoWPAPI {
 	 */
 	function addACFDataPostV2() {
 		// Posts
-		register_api_field( 'post',
+		register_rest_field( 'post',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -228,7 +228,7 @@ class ACFtoWPAPI {
 	    );
 
 		// Pages
-		register_api_field( 'page',
+		register_rest_field( 'page',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -243,7 +243,7 @@ class ACFtoWPAPI {
 			'_builtin' => false
 		));
 		foreach($types as $key => $type) {
-			register_api_field( $type,
+			register_rest_field( $type,
 		        'acf',
 		        array(
 		            'get_callback'    => array( $this, 'addACFDataPostV2cb' ),
@@ -253,16 +253,16 @@ class ACFtoWPAPI {
 		    );
 		}
 	}
-	
+
 	/**
 	 * Returns the ACF data to be added to the JSON response posts
-	 * 
+	 *
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
 	 *
 	 * @param array 	$object 		The object to get data for
 	 * @param string 	$fieldName 		The name of the field being completed
 	 * @param object 	$request 		The WP_REST_REQUEST object
-	 * 
+	 *
 	 * @return array 	The data for this object type
 	 *
 	 * @see ACFtoWPAPI::addACFDataPostV2()
@@ -281,7 +281,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataTermV2() {
-		register_api_field( 'term',
+		register_rest_field( 'term',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataTermV2cb' ),
@@ -293,13 +293,13 @@ class ACFtoWPAPI {
 
 	/**
 	 * Returns the ACF data to be added to the JSON response for taxonomy terms
-	 * 
+	 *
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
 	 *
 	 * @param array 	$object 		The object to get data for
 	 * @param string 	$fieldName 		The name of the field being completed
 	 * @param object 	$request 		The WP_REST_REQUEST object
-	 * 
+	 *
 	 * @return array 	The data for this object type
 	 *
 	 * @see ACFtoWPAPI::addACFDataTermV2()
@@ -318,7 +318,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataUserV2() {
-		register_api_field( 'user',
+		register_rest_field( 'user',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataUserV2cb' ),
@@ -330,13 +330,13 @@ class ACFtoWPAPI {
 
 	/**
 	 * Returns the ACF data to be added to the JSON response for users
-	 * 
+	 *
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
 	 *
 	 * @param array 	$object 		The object to get data for
 	 * @param string 	$fieldName 		The name of the field being completed
 	 * @param object 	$request 		The WP_REST_REQUEST object
-	 * 
+	 *
 	 * @return array 	The data for this object type
 	 *
 	 * @see ACFtoWPAPI::addACFDataUserV2()
@@ -355,7 +355,7 @@ class ACFtoWPAPI {
 	 * @since 1.3.0
 	 */
 	function addACFDataCommentV2() {
-		register_api_field( 'comment',
+		register_rest_field( 'comment',
 	        'acf',
 	        array(
 	            'get_callback'    => array( $this, 'addACFDataCommentV2cb' ),
@@ -367,13 +367,13 @@ class ACFtoWPAPI {
 
 	/**
 	 * Returns the ACF data to be added to the JSON response for comments
-	 * 
+	 *
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
 	 *
 	 * @param array 	$object 		The object to get data for
 	 * @param string 	$fieldName 		The name of the field being completed
 	 * @param object 	$request 		The WP_REST_REQUEST object
-	 * 
+	 *
 	 * @return array 	The data for this object type
 	 *
 	 * @see ACFtoWPAPI::addACFDataCommentV2()
@@ -388,13 +388,13 @@ class ACFtoWPAPI {
 	 * Returns an array of Advanced Custom Fields data for the given record
 	 *
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
-	 * 
+	 *
 	 * @param int 		$id 		The ID of the object to get
 	 * @param string 	$type 		The type of the object to get
 	 * @param array 	$object 	The full object being requested, only required for specific $types
 	 *
 	 * @return array 	The Advanced Custom Fields data for the supplied record
-	 * 
+	 *
 	 * @since 1.3.0
 	 */
 	private function _getData($id, $type = 'post', $object = array()) {
@@ -446,12 +446,12 @@ class ACFtoWPAPI {
 
 	/**
 	 * The callback for the `wp/v2/acf/options` endpoint
-	 * 
+	 *
 	 * @author Chris Hutchinson <chris_hutchinson@me.com>
 	 *
 	 * @param WP_REST_Request 	$request 	The WP_REST_Request object
 	 *
-	 * @return array|string 	The single requested option, or all options 
+	 * @return array|string 	The single requested option, or all options
 	 *
 	 * @see ACFtoWPAPI::addACFOptionRouteV2()
 	 *
@@ -505,7 +505,7 @@ class ACFtoWPAPI {
 	 *
 	 * @param string 	$name 	The option name being requested
 	 *
-	 * @return mixed 	The data for the supplied option	
+	 * @return mixed 	The data for the supplied option
 	 *
 	 * @since 1.3.0
 	 */


### PR DESCRIPTION
This updates all calls to `register_api_field` to use `register_rest_field` instead, as the former is deprecated, and will result in this unwanted header:

```
X-WP-DeprecatedFunction: register_api_field (since WPAPI-2.0; use register_rest_field instead)
```